### PR TITLE
Removed unnecessary printer models

### DIFF
--- a/BIBO2Touch.ini
+++ b/BIBO2Touch.ini
@@ -12,49 +12,12 @@ config_version = 0.0.1-beta2
 # Printer model name will be shown by the installation wizard.
 
 [printer_model:BIBO2]
-name = BIBO2 Touch Dual extrusion
+name = BIBO2 Touch
 variants = 0.4
 technology = FFF
 family = BIBO2
 bed_model = BIBO2_bed.stl
 bed_texture = BIBO2.svg
-default_materials = Generic PLA @BIBO2; Generic PETG @BIBO2; Generic ABS @BIBO2; Prusament PLA @BIBO2; Prusament PETG @BIBO2;
-
-[printer_model:BIBO2E1]
-name = BIBO2 Touch E1 right only extrusion
-variants = 0.4
-technology = FFF
-family = BIBO2
-bed_model = BIBO2_bed.stl
-bed_texture = BIBO2.svg
-default_materials = Generic PLA @BIBO2; Generic PETG @BIBO2; Generic ABS @BIBO2; Prusament PLA @BIBO2; Prusament PETG @BIBO2;
-
-[printer_model:BIBO2E2]
-name = BIBO2 Touch E2 left only extrusion
-variants = 0.4
-technology = FFF
-family = BIBO2
-bed_model = BIBO2_bed.stl
-bed_texture = BIBO2.svg
-default_materials = Generic PLA @BIBO2; Generic PETG @BIBO2; Generic ABS @BIBO2; Prusament PLA @BIBO2; Prusament PETG @BIBO2;
-
-# Ditto Printing options with custom beds and special start end gcode for print duplication from one nozzle to the other
-[printer_model:BIBO2E1E2DITTO]
-name = BIBO2 E1 right E2 Ditto
-variants = 0.4
-technology = FFF
-family = BIBO2
-# bed_model = BIBO2_bed.stl
-# bed_texture = BIBO2.svg
-default_materials = Generic PLA @BIBO2; Generic PETG @BIBO2; Generic ABS @BIBO2; Prusament PLA @BIBO2; Prusament PETG @BIBO2;
-
-[printer_model:BIBO2E2E1DITTO]
-name = BIBO2 E2 left E1 Ditto
-variants = 0.4
-technology = FFF
-family = BIBO2
-# bed_model = BIBO2_bed.stl
-# bed_texture = BIBO2.svg
 default_materials = Generic PLA @BIBO2; Generic PETG @BIBO2; Generic ABS @BIBO2; Prusament PLA @BIBO2; Prusament PETG @BIBO2;
 
 # All presets starting with asterisk, for example *common*, are intermediate and they will
@@ -838,7 +801,7 @@ z_offset = 0
 
 [printer:BIBO2 Touch E1 right only extrusion]
 inherits = *common*
-printer_model = BIBO2E1
+printer_model = BIBO2
 printer_variant = 0.4
 extruder_colour = #FFFF00
 printer_notes = Do not remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_BIBO\nPRINTER_MODEL_BIBO2E1
@@ -861,7 +824,7 @@ z_offset = 0
 
 [printer:BIBO2 Touch E2 left only extrusion]
 inherits = *common*
-printer_model = BIBO2E2
+printer_model = BIBO2
 printer_variant = 0.4
 extruder_colour = #229403
 printer_notes = Do not remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_BIBO\nPRINTER_MODEL_BIBO2E2
@@ -884,7 +847,7 @@ z_offset = 0
 # Ditto Printing options with custom beds and special start end gcode for print duplication from one nozzle to the other
 [printer:BIBO2 E1 right E2 Ditto]
 inherits = BIBO2 Touch E1 right only extrusion
-printer_model = BIBO2E1E2DITTO
+printer_model = BIBO2
 bed_shape = 0x-93,33x-93,33x93,0x93
 before_layer_gcode = ;BEFORE_LAYER_CHANGE\n;[layer_z]\nM104 S{temperature[0]} T1 ; set 2nd nozzle heater to print temperature\n
 start_gcode = ;Start code PrusaSlicer BIBO 2 printers E1 only (i.e. T0)\nM420 S1 ; Turn on Ditto Printing\nG21            ; set units to metric\nG90            ; absolute positioning\nM107           ; start with the fan off\nM190 S{first_layer_bed_temperature[0] - 5} ; wait for bed temp\nM140 S{first_layer_bed_temperature[0]}  ; continue bed heating to full temp while other things are happening\nM104 S{first_layer_temperature[0]} T0 ; set 1st nozzle heater to first layer temperature\nM104 S{first_layer_temperature[0]} T1 ; set 2nd nozzle heater to same first layer temperature\nM105 ; Report Temperatures\nM109 S{first_layer_temperature[0]} T0 ; wait for 1st nozzle heat to first layer temperature\nM109 S{first_layer_temperature[0]} T1 ; wait for 2nd nozzle heat to same first layer temperature\nM105 ; Report Temperatures\nG28 X0 Y0        ; move X/Y to min endstops\nG28 Z0           ; move Z to min endstops\nG1 Y0 F1200 E0   ; move Y to min endstop and extrude 0 filament\nT[initial_tool]  ; switch to initial tool position\nG92 E0.0         ; reset extruder\nG28 ; Home all axis\nG1 Y0 F1200 E0 ; move Y to min endstop and reset extruder\nG92 E0.0 ; zero the current extruder coordinate\nM117 Cleaning... ; Put Cleaning message on screen, Attempt Nozzle Wipe (for ooze free startup)\nG1 X-15.0 Y-92.9 Z0.3 F2400.0     ; move to start-line position\nG1 X15.0 Y-92.9 Z0.3 F1000.0 E2   ; draw 1st line\nG1 X15.0 Y-92.6 Z0.3 F3000.0      ; move to side a little\nG1 X-15.0 Y-92.6 Z0.3 F1000.0 E4  ; draw 2nd line\nG1 X-15.0 Y-92.3 Z0.3 F3000.0     ; move to side a little\nG1 X15.0 Y-92.3 Z0.3 F1000.0 E6   ; draw 3rd line\nG1 X15.0 Y-92 Z0.3 F3000.0        ; move to side a little\nG1 X-15.0 Y-92 Z0.3 F1000.0 E8    ; draw 4th line\nG92 E0.0 ; reset extruder and zero the current extruder coordinate before printing\nM117 BIBO E1 now Printing... ; Put now printing message on screen
@@ -892,7 +855,7 @@ end_gcode = ;BIBO End GCode\nM107 ; turn fans off\nG91 ; Relative positioning\nG
 
 [printer:BIBO2 E2 left E1 Ditto]
 inherits = BIBO2 Touch E2 left only extrusion
-printer_model = BIBO2E2E1Ditto
+printer_model = BIBO2
 bed_shape = -33x-93,0x-93,0x93,-33x93
 before_layer_gcode = ;BEFORE_LAYER_CHANGE\n;[layer_z]\nM104 S{temperature[0]} T0 ; set 1st nozzle heater to print temperature\n
 start_gcode = ;Start code PrusaSlicer BIBO 2 printers E2 only (i.e. T1)\nM420 S1 ; Turn on Ditto Printing\nG21  ; set units to metric\nG90  ; absolute positioning\nM107 ; start with the fan off\nM140 S{first_layer_bed_temperature[0] - 5} ; set bed temp\nM105 ; Report Temperatures\nM190 S{first_layer_bed_temperature[0]} ; wait for bed temp\nM104 S{first_layer_temperature[0]} T0 ; set 1st nozzle heater to ditto print temperature\nM104 S{first_layer_temperature[0]} T1 ; set 2nd nozzle heater to first layer temperature\nM105 ; Report Temperatures\nM109 S{first_layer_temperature[0]} T0 ; set 1st nozzle heater to ditto printing temperature\nM109 S{first_layer_temperature[0]} T1 ; Wait for 2nd nozzle heater to first layer temperature\nM105 ; Report Temperatures\nG28 X0 Y0  ; move X/Y to min endstops\nG28 Z0     ; move Z to min endstops\nG1 Z2 F400 ; move the print bed down 2mm\nT0 ; switch to tool position T0\nG90 ; absolute positioning\nG92 E0.0 ; zero the current extruder coordinate\nG28 ; Home all axis\nG1 Y0 F1200 E0 ; move Y to min endstop and reset extruder\nG92 E0.0 ; zero the current extruder coordinate\nT1 ; switch to tool position T1\nG92 E0.0 ; zero the current extruder coordinate\nM117 E2 nozzle wipe... ; Put Nozzle wipe message on screen, Attempt Nozzle Wipe (for ooze free startup)\nG1 X-15.0 Y-92.9 Z0.3 F2400.0       ; move to start-line position\nG1 X15.0 Y-92.9 Z0.3 F1000.0 E2     ; draw 1st line\nG1 X15.0 Y-92.6 Z0.3 F3000.0        ; move to side a little\nG1 X-15.0 Y-92.6 Z0.3 F1000.0 E4    ; draw 2nd line\nG1 X-15.0 Y-92.3 Z0.3 F3000.0       ; move to side a little\nG1 X15.0 Y-92.3 Z0.3 F1000.0 E6     ; draw 3rd line\nG1 X15.0 Y-92 Z0.3 F3000.0          ; move to side a little\nG1 X-15.0 Y-92 Z0.3 F1000.0 E8      ; draw 4th line\nG92 E0.0 ; reset extruder coordinate to zero before printing\nM117 BIBO Now Printing from E2... ; Put now printing message on screen


### PR DESCRIPTION
With this change, only one printer will be visible in configuration wizard (BIBO2 Touch), but other printer variants (E1 only, E2 only, etc.) will be still installed and available for users.